### PR TITLE
Compress output images

### DIFF
--- a/daily_raster/daily_raster.py
+++ b/daily_raster/daily_raster.py
@@ -238,11 +238,18 @@ profile = {
     'height': num_lats,
     'width': num_lons,
     'count': 1,
-    'driver':"GTiff",
+    'driver': "GTiff",
     'transform': affine.Affine(float(cellsize), 0, -180, 
-              0, -float(cellsize), 90)}
+                               0, -float(cellsize), 90),
+    'TILED': 'YES',
+    'BIGTIFF': 'NO',
+    'INTERLEAVE': 'BAND',
+    'COMPRESS': 'DEFLATE',
+    'PREDICTOR': '3'
+}
 
-out_tif = thedate+".tiff"
+
+out_tif = thedate+".tif"
 
 with rio.open(path_to_tiff + out_tif, 'w', **profile) as dst:
     dst.write(np.flipud(vessel_hours).astype(profile['dtype']), indexes=1)


### PR DESCRIPTION
Added the Rasterio equivalent of: `$ gdal_translate 20120216.tiff comp.tif -co TILED=YES -co BIGTIFF=NO -co INTERLEAVE=BAND -co COMPRESS=DEFLATE -co PREDICTOR=3`
